### PR TITLE
Update regex to match URL encoded params

### DIFF
--- a/src/main/java/helpers/EncodingHelper.java
+++ b/src/main/java/helpers/EncodingHelper.java
@@ -74,7 +74,7 @@ public class EncodingHelper {
 
         // TODO: message should be valid XML, so apply decoders and try to parse it until parsing is valid
 
-        if (message.matches("%[0-9A-Fa-f]{2}") && urldecode(message) != message) {
+        if (message.matches(".*%[0-9A-Fa-f]{2}.*") && urldecode(message) != message) {
             encodings.add("url");
             message = urldecode(message);
         }


### PR DESCRIPTION
Hello !
Saw your talk at DefCon and wanted to check this out on a real case. I had to patch this specific regex, otherwise my URLencoded and base64 never got recognized by the plugin.